### PR TITLE
Remove signal traps inside the WEBrick server Thread

### DIFF
--- a/lib/mimic.rb
+++ b/lib/mimic.rb
@@ -45,21 +45,21 @@ module Mimic
       @logger ||= Logger.new(StringIO.new)
     end
 
-    def serve(host_app, port, should_fork, should_trap)
+    def serve(app, options)
       if options[:fork]
         @thread = Thread.fork do
-          start_service(host_app, options)
+          start_service(app, options)
         end
 
-        wait_for_service(host_app.hostname, options[:port])
+        wait_for_service(app.hostname, options[:port])
 
       else
-        start_service(host_app, options)
+        start_service(app, options)
       end
     end
 
-    def start_service(host_app, options)
-      Rack::Handler::WEBrick.run(host_app.url_map, {
+    def start_service(app, options)
+      Rack::Handler::WEBrick.run(app.url_map, {
         :Port       => options[:port],
         :Logger     => logger,
         :AccessLog  => logger,

--- a/lib/mimic.rb
+++ b/lib/mimic.rb
@@ -10,8 +10,7 @@ module Mimic
     :hostname => 'localhost',
     :port => MIMIC_DEFAULT_PORT,
     :remote_configuration_path => nil,
-    :fork => true,
-    :trap_signals => true
+    :fork => true
   }
 
   def self.mimic(options = {}, &block)
@@ -67,9 +66,9 @@ module Mimic
       }) do |server|
         @server = server
 
-        if options[:trap_signals]
-          trap("TERM") { @server.shutdown }
-          trap("INT")  { @server.shutdown }
+        old = trap('EXIT') do
+          old.call if old
+          @server.shutdown
         end
       end
     end


### PR DESCRIPTION
Hi Luke,

while using Mimic in a rspec test suite, we found out that [a trap INT inside start_service]([https://github.com/lukeredpath/mimic/blob/5db3394/lib/mimic.rb#L69) overrides the one set up by the rspec runner itself, thus making impossible to use `^C` to stop the test suite.

This happens because UNIX signals are process-wide, and `trap()` is done in the same process - as the WEBRick server is started in a new Thread.

As trapping specific signals to shut down the WEBrick sockets looks pointless to me, because a signal is not the only way a process could exit - and anyway the OS will take care of closing open file descriptors - I removed the traps and added the Ruby generic trap('EXIT'), possibly preserving any other trapexit handler.

I've also changed the parameter passing between methods, as too many parameters were floating around - hope that's appreciated :-).

Cheers,

~Marcello
