### PR TITLE
Ruby 1.9 fixes

### DIFF
--- a/features/steps/http_client_steps.rb
+++ b/features/steps/http_client_steps.rb
@@ -58,3 +58,11 @@ Then /^I should receive an HTTP (\d+) response with the Plist value "([^\"]*)" f
   plist = Plist.parse_xml(@httpclient.last_response.to_s)
   plist.value_for_key_path(key_path).should == json_value
 end
+
+# For debugging. You'll need to gem install bcat
+Then /^show me the response$/ do
+  IO.popen("bcat", "w") do |bcat|
+    bcat.puts @httpclient.last_response
+  end
+end
+

--- a/lib/mimic/fake_host.rb
+++ b/lib/mimic/fake_host.rb
@@ -180,7 +180,7 @@ module Mimic
       end
       
       def unmatched_response
-        [404, "", {}]
+        [404, {}, ""]
       end
       
       def response_for_request(request)

--- a/spec/fake_host_spec.rb
+++ b/spec/fake_host_spec.rb
@@ -81,9 +81,9 @@ describe "Mimic::FakeHost" do
   
   RSpec::Matchers.define :match_rack_response do |code, headers, body|
     match do |actual|
-      (actual[0].should == code) &&
-      (actual[1].should include(headers)) &&
-      (actual[2].should include(body))
+      (actual[0] == code) &&
+      (headers.all? {|k, v| actual[1][k] == v }) &&
+      (actual[2].include?(body))
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,6 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), *%w[.. lib]))
 require 'mimic'
 require 'rspec/expectations'
 
-Rspec.configure do |config|
+RSpec.configure do |config|
   config.mock_with :mocha
 end


### PR DESCRIPTION
Made `rake spec` and `rake features` pass on Ruby 1.9.2
