### PR TITLE
fix interrupt handling

### DIFF
--- a/lib/mimic.rb
+++ b/lib/mimic.rb
@@ -67,8 +67,13 @@ module Mimic
       }) do |server|
         @server = server
 
-        old = trap('EXIT') do
-          old.call if old
+        @previous_int_handler = trap('INT') do
+          begin
+            # support case of default command String names
+            @previous_int_handler.call if @previous_int_handler and @previous_int_handler.respond_to?("call")
+          rescue StandardError => e
+            puts "Error occurred invoking previous interrupt handler: #{e.class} #{e.to_s}"
+          end
           @server.shutdown
         end
       end


### PR DESCRIPTION
I had to make the following changes otherwise Ctrl-C/interrupt was not handled appropriately, at least on Fedora Linux.  Ctrl-C fires the INT signal, not EXIT (that occurs when the process actually exits), also improved previous interrupt command handling.

sample case:

```

#!/usr/bin/env ruby
require 'mimic'
# otherwise: mimic.rb:89:in `rescue in listening?': uninitialized constant Mimic::Server::SocketError
require 'socket'

Mimic.mimic(:port => 11988, :fork => false) do
  get("/some/other/path").returning("Redirecting...", 301, {"Location" => "somewhere else"})
  get("/some/path").returning("Hello World", 200)
  post("/some/path").returning("Created!", 201)
end
```

existing tests still pass
