### PR TITLE
Require socket

### DIFF
--- a/lib/mimic.rb
+++ b/lib/mimic.rb
@@ -2,6 +2,7 @@ require 'mimic/fake_host'
 require 'singleton'
 require 'rack'
 require 'logger'
+require 'socket'
 
 module Mimic
   MIMIC_DEFAULT_PORT = 11988


### PR DESCRIPTION
when loading mimic, you get the following error:

/Users/hubert/.rbenv/versions/1.9.3-p448/gemsets/comptroller/gems/mimic-0.4.3/lib/mimic.rb:89:in `rescue in listening?': uninitialized constant Mimic::Server::SocketError (NameError)

requiring socket explicitly in mimic.rb takes care of it.
