### PR TITLE
Pass listen hostname on to Thin server

### DIFF
--- a/features/configuring_mimic_listen_options.feature
+++ b/features/configuring_mimic_listen_options.feature
@@ -1,0 +1,20 @@
+Feature: Configuring mimic listen options
+  In order to use Mimic on platforms with mixed IPv4 and IPv6 support
+  As a developer
+  I want to be able to configure Mimic to listen on a specific interface
+  
+  Scenario: Configuring mimic to listen on all IPv4 loopback
+    Given I have a mimic specification with:
+      """
+      Mimic.mimic(:hostname => '127.0.0.1', :port => 11988).get("/some/path").returning("Hello World")
+      """
+    When I make an HTTP GET request to "http://127.0.0.1:11988/some/path"
+    Then I should receive an HTTP 200 response with a body matching "Hello World"
+
+  Scenario: Configuring mimic to listen on all interfaces
+    Given I have a mimic specification with:
+      """
+      Mimic.mimic(:hostname => '0.0.0.0', :port => 11988).get("/some/path").returning("Hello World")
+      """
+    When I make an HTTP GET request to "http://0.0.0.0:11988/some/path"
+    Then I should receive an HTTP 200 response with a body matching "Hello World"

--- a/lib/mimic.rb
+++ b/lib/mimic.rb
@@ -62,6 +62,7 @@ module Mimic
 
     def start_service(app, options)
       Rack::Handler::Thin.run(app.url_map, {
+        :Host       => options[:hostname],
         :Port       => options[:port],
         :Logger     => logger,
         :AccessLog  => logger,


### PR DESCRIPTION
So that you can tell the web server what interface to listen on. This can be
useful if you want to tell Mimic to listen on a specific loopback interface
(e.g. `127.0.0.2`) or protocol (e.g. IPv4 or IPv6).

Previously, passing this option would change where Mimic polled the web server
to check that it had come up, but wouldn't actually change where the web server
was listening, which was unexpected.

This was made most apparent by the move from Webrick to Thin in 319b83e
(v0.4.4), because Thin on Mac OS X appears to bind to `localhost` on IPv6.
The following test would fail on Thin, but not Webrick:

```
Listening on localhost:11988, CTRL+C to stop
  Scenario: Configuring mimic to listen on all IPv4 loopback                      # features/configuring_mimic_listen_options.feature:6
    Given I have a mimic specification with:                                      # features/steps/mimic_steps.rb:1
      """
      Mimic.mimic(:hostname => '127.0.0.1', :port => 11988).get("/some/path").returning("Hello World")
      """
      Socket did not open within 5 seconds (SocketError)
      ./features/support/mimic_runner.rb:5:in `instance_eval'
      ./lib/mimic.rb:56:in `serve'
      ./lib/mimic.rb:24:in `block in mimic'
      ./lib/mimic.rb:22:in `tap'
      ./lib/mimic.rb:22:in `mimic'
      (eval):1:in `evaluate'
      ./features/support/mimic_runner.rb:5:in `instance_eval'
      ./features/support/mimic_runner.rb:5:in `evaluate'
      ./features/steps/mimic_steps.rb:2:in `/^I have a mimic specification with:$/'
      features/configuring_mimic_listen_options.feature:7:in `Given I have a mimic specification with:'
    When I make an HTTP GET request to "http://127.0.0.1:11988/some/path"         # features/steps/http_client_steps.rb:22
    Then I should receive an HTTP 200 response with a body matching "Hello World" # features/steps/http_client_steps.rb:36
```

I think the two hosts that I've used in the tests should be representative
enough of the desired behaviour. I was hoping to use some more explicit
examples, but I couldn't use the following because they weren't platform
independent:
- `127.0.0.2` doesn't work on OS X unless you manually add the alias to lo0
- `::1` doesn't work on Travis because IPv6 is disabled
