### PR TITLE
Allow non-empty bodies for 404 stubs

### DIFF
--- a/features/stubbing_requests_by_path.feature
+++ b/features/stubbing_requests_by_path.feature
@@ -19,6 +19,14 @@ Feature: Stubbing requests by path
     When I make an HTTP GET request to "http://localhost:11988/some/path"
     Then I should receive an HTTP 200 response with a body matching "Hello World"
     
+  Scenario: Stubbing a GET request to /some/path and returning a 404 and non-empty response
+    Given I have a mimic specification with:
+      """
+      Mimic.mimic(:port => 11988).get("/some/path").returning("Hello World", 404)
+      """
+    When I make an HTTP GET request to "http://localhost:11988/some/path"
+    Then I should receive an HTTP 404 response with a body matching "Hello World"
+
   Scenario: Requesting an un-stubbed path and getting a 404 response
     Given I have a mimic specification with:
       """

--- a/lib/mimic/fake_host.rb
+++ b/lib/mimic/fake_host.rb
@@ -58,7 +58,7 @@ module Mimic
       @app = Sinatra.new
       @app.use Rack::CommonLogger, self.log if self.log
       @app.not_found do
-        [404, {}, ""]
+        [404, {}, nil]
       end
       @app.helpers do
         include Helpers


### PR DESCRIPTION
#### Add test for 404 and non-empty response

This fails because it's currently overridden by the un-stubbed path handler.
#### Don't override body for all 404 stubs

This makes the test for 404 stubs with bodies in the preceding commit pass.
However it's the wrong solution to the problem, because it makes the tests
fail for un-stubbed paths with empty bodies.

I'm not sure what the correct solution to this is, but I'm hoping this
commit helps demonstrate where the problem is and can prompt a discussion
about the correct solution.

---

Feel free to discuss this further or create a new branch/PR with additional commits..
